### PR TITLE
chore: upgrade ssz to work with 0.14.0-dev

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,12 +1,724 @@
-//! This module provides functions for serializing and deserializing
-//! data structures with the SSZ method.
+//! The code bellow is essentially a combination of https://github.com/Raiden1411/zabi and https://github.com/gballet/ssz.zig
+//! to the most recent version of zig with a couple of stylistic changes and support for
+//! other zig types.
 
 const std = @import("std");
-const ArrayList = std.ArrayList;
-const builtin = std.builtin;
-const sha256 = std.crypto.hash.sha2.Sha256;
-const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
+const testing = std.testing;
 const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+const sha256 = std.crypto.hash.sha2.Sha256;
+
+/// Set of possible errors while performing ssz decoding.
+pub const SSZDecodeErrors = Allocator.Error || error{ InvalidEnumType, IndexOutOfBounds };
+
+/// Performs ssz decoding according to the [specification](https://ethereum.org/developers/docs/data-structures-and-encoding/ssz).
+pub fn decodeSSZ(comptime T: type, serialized: []const u8) SSZDecodeErrors!T {
+    const info = @typeInfo(T);
+
+    switch (info) {
+        .bool => return serialized[0] != 0,
+        .int => |int_info| return std.mem.readInt(T, serialized[0..@divExact(int_info.bits, 8)], .little),
+        .optional => |opt_info| {
+            if (serialized.len > 0) {
+                const index = serialized[0];
+
+                if (index != 0) {
+                    const result: opt_info.child = try decodeSSZ(opt_info.child, serialized[1..]);
+                    return result;
+                } else return null;
+            } else return null;
+        },
+        .@"enum" => {
+            const to_enum = std.meta.stringToEnum(T, serialized[0..]) orelse return error.InvalidEnumType;
+
+            return to_enum;
+        },
+        .array => |arr_info| {
+            if (arr_info.child == u8) {
+                if (serialized.len >= arr_info.len) {
+                    return serialized[0..arr_info.len].*;
+                } else {
+                    return error.IndexOutOfBounds;
+                }
+            }
+
+            var result: T = undefined;
+
+            if (arr_info.child == bool) {
+                for (serialized, 0..) |byte, bindex| {
+                    var index: u8 = 0;
+                    var bit = byte;
+                    while (bindex * 8 + index < arr_info.len and index < 8) : (index += 1) {
+                        result[bindex * 8 + index] = bit & 1 == 1;
+                        bit >>= 1;
+                    }
+                }
+
+                return result;
+            }
+
+            if (isStaticType(arr_info.child)) {
+                comptime var index = 0;
+                const size = @sizeOf(arr_info.child);
+
+                inline while (index < arr_info.len) : (index += 1) {
+                    result[index] = try decodeSSZ(arr_info.child, serialized[index * size .. (index + 1) * size]);
+                }
+
+                return result;
+            }
+
+            const size = std.mem.readInt(u32, serialized[0..4], .little) / @sizeOf(u32);
+            const indices = std.mem.bytesAsSlice(u32, serialized[0 .. size * 4]);
+
+            var index: usize = 0;
+            while (index < size) : (index += 1) {
+                const final = if (index < size - 1) indices[index + 1] else serialized.len;
+                const start = indices[index];
+
+                if (start >= serialized.len or final > serialized.len)
+                    return error.IndexOutOfBounds;
+
+                result[index] = try decodeSSZ(arr_info.child, serialized[start..final]);
+            }
+
+            return result;
+        },
+        .vector => |vec_info| {
+            var result: T = undefined;
+
+            if (vec_info.child == bool) {
+                for (serialized, 0..) |byte, bindex| {
+                    var index: u8 = 0;
+                    var bit = byte;
+                    while (bindex * 8 + index < vec_info.len and index < 8) : (index += 1) {
+                        result[bindex * 8 + index] = bit & 1 == 1;
+                        bit >>= 1;
+                    }
+                }
+
+                return result;
+            }
+
+            comptime var index = 0;
+            const size = @sizeOf(vec_info.child);
+
+            inline while (index < vec_info.len) : (index += 1) {
+                result[index] = try decodeSSZ(vec_info.child, serialized[index * size .. (index + 1) * size]);
+            }
+
+            return result;
+        },
+        .pointer => return serialized[0..],
+        .@"union" => |union_info| {
+            const union_index = try decodeSSZ(u8, serialized);
+
+            inline for (union_info.fields, 0..) |field, i| {
+                if (union_index == i) {
+                    return @unionInit(T, field.name, try decodeSSZ(field.type, serialized[1..]));
+                }
+            }
+        },
+        .@"struct" => |struct_info| {
+            comptime var num_fields = 0;
+            inline for (struct_info.fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .bool, .int, .array => continue,
+                    .@"struct" => {
+                        if (isStaticType(field.type)) {
+                            continue;
+                        } else {
+                            num_fields += 1;
+                        }
+                    },
+                    else => num_fields += 1,
+                }
+            }
+            var indices: [num_fields]u32 = undefined;
+            var result: T = undefined;
+
+            comptime var index = 0;
+            comptime var field_index = 0;
+            inline for (struct_info.fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .bool, .int, .array => {
+                        @field(result, field.name) = try decodeSSZ(field.type, serialized[index .. index + @sizeOf(field.type)]);
+                        index += @sizeOf(field.type);
+                    },
+                    .@"struct" => {
+                        if (isStaticType(field.type)) {
+                            @field(result, field.name) = try decodeSSZ(field.type, serialized[index .. index + @sizeOf(field.type)]);
+                            index += @sizeOf(field.type);
+                        }
+                    },
+                    else => {
+                        indices[field_index] = try decodeSSZ(u32, serialized[index .. index + 4]);
+                        index += 4;
+                        field_index += 1;
+                    },
+                }
+            }
+
+            comptime var final_index = 0;
+            inline for (struct_info.fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .bool, .int, .array => continue,
+                    .@"struct" => {
+                        if (isStaticType(field.type)) {
+                            continue;
+                        }
+                    },
+                    else => {
+                        const final = if (final_index == indices.len - 1) serialized.len else indices[final_index + 1];
+                        @field(result, field.name) = try decodeSSZ(field.type, serialized[indices[final_index]..final]);
+                        final_index += 1;
+                    },
+                }
+            }
+
+            return result;
+        },
+        else => @compileError("Unsupported type " ++ @typeName(T)),
+    }
+
+    // it should never be reached
+    unreachable;
+}
+
+/// Performs ssz encoding according to the [specification](https://ethereum.org/developers/docs/data-structures-and-encoding/ssz).
+/// Almost all zig types are supported.
+///
+/// Caller owns the memory
+pub fn encodeSSZ(allocator: Allocator, value: anytype) Allocator.Error![]u8 {
+    var list = std.ArrayList(u8).init(allocator);
+    errdefer list.deinit();
+
+    try encodeItem(value, &list);
+    return try list.toOwnedSlice();
+}
+
+fn encodeItem(value: anytype, list: *std.ArrayList(u8)) Allocator.Error!void {
+    const info = @typeInfo(@TypeOf(value));
+    var writer = list.writer();
+
+    switch (info) {
+        .bool => try writer.writeInt(u8, @intFromBool(value), .little),
+        .int => |int_info| {
+            switch (int_info.bits) {
+                8, 16, 32, 64, 128, 256 => try writer.writeInt(@TypeOf(value), value, .little),
+                else => @compileError(std.fmt.comptimePrint("Unsupported {d} bits for ssz encoding", .{int_info.bits})),
+            }
+        },
+        .comptime_int => {
+            const size = comptime computeSize(@intCast(value)) * 8;
+            switch (size) {
+                8, 16, 32, 64, 128, 256 => try writer.writeInt(@Type(.{ .Int = .{ .signedness = .unsigned, .bits = size } }), value, .little),
+                else => @compileError(std.fmt.comptimePrint("Unsupported {d} bits for ssz encoding", .{size})),
+            }
+        },
+        .null => return,
+        .optional => {
+            if (value) |val| {
+                try writer.writeInt(u8, 1, .little);
+                return try encodeItem(val, list);
+            } else try writer.writeInt(u8, 0, .little);
+        },
+        .@"union" => |union_info| {
+            if (union_info.tag_type == null)
+                @compileError("Untagged unions are not supported");
+
+            inline for (union_info.fields, 0..) |field, i| {
+                if (@intFromEnum(value) == i) {
+                    try writer.writeInt(u8, i, .little);
+                    return try encodeItem(@field(value, field.name), list);
+                }
+            }
+        },
+        .pointer => |ptr_info| {
+            switch (ptr_info.size) {
+                .One => return try encodeItem(value.*, list),
+                .Slice => {
+                    if (ptr_info.child == u8) {
+                        try writer.writeAll(value);
+                        return;
+                    }
+
+                    for (value) |val| {
+                        try encodeItem(val, list);
+                    }
+                },
+                else => @compileError("Unsupported pointer type " ++ @typeName(@TypeOf(value))),
+            }
+        },
+        .vector => |vec_info| {
+            if (vec_info.child == bool) {
+                var as_byte: u8 = 0;
+                for (value, 0..) |val, i| {
+                    if (val) {
+                        as_byte |= @as(u8, 1) << @as(u3, @truncate(i));
+                    }
+
+                    if (i % 8 == 7) {
+                        try writer.writeByte(as_byte);
+                        as_byte = 0;
+                    }
+                }
+
+                if (as_byte % 8 != 0)
+                    try writer.writeByte(as_byte);
+
+                return;
+            }
+
+            for (0..vec_info.len) |i| {
+                try encodeItem(value[i], list);
+            }
+        },
+        .@"enum", .enum_literal => try writer.writeAll(@tagName(value)),
+        .error_set => try writer.writeAll(@errorName(value)),
+        .array => |arr_info| {
+            if (arr_info.child == u8) {
+                try writer.writeAll(&value);
+                return;
+            }
+
+            if (arr_info.child == bool) {
+                var as_byte: u8 = 0;
+                for (value, 0..) |val, i| {
+                    if (val) {
+                        as_byte |= @as(u8, 1) << @as(u3, @truncate(i));
+                    }
+
+                    if (i % 8 == 7) {
+                        try writer.writeByte(as_byte);
+                        as_byte = 0;
+                    }
+                }
+
+                if (as_byte % 8 != 0)
+                    try writer.writeByte(as_byte);
+
+                return;
+            }
+
+            if (isStaticType(arr_info.child)) {
+                for (value) |val| {
+                    try encodeItem(val, list);
+                }
+                return;
+            }
+
+            var offset_start = list.items.len;
+
+            for (value) |_| {
+                try writer.writeInt(u32, 0, .little);
+            }
+
+            for (value) |val| {
+                std.mem.writeInt(u32, list.items[offset_start .. offset_start + 4][0..4], @as(u32, @truncate(list.items.len)), .little);
+                try encodeItem(val, list);
+                offset_start += 4;
+            }
+        },
+        .@"struct" => |struct_info| {
+            comptime var start: usize = 0;
+            inline for (struct_info.fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .int, .bool, .array => start += @sizeOf(field.type),
+                    .@"struct" => {
+                        if (isStaticType(field.type)) {
+                            start += @sizeOf(field.type);
+                        }
+                    },
+                    else => start += 4,
+                }
+            }
+
+            var accumulate: usize = start;
+            inline for (struct_info.fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .int, .bool, .array => try encodeItem(@field(value, field.name), list),
+                    .@"struct" => {
+                        if (isStaticType(field.type)) {
+                            try encodeItem(@field(value, field.name), list);
+                        }
+                    },
+                    else => {
+                        try encodeItem(@as(u32, @truncate(accumulate)), list);
+                        accumulate += sizeOfValue(@field(value, field.name));
+                    },
+                }
+            }
+
+            if (accumulate > start) {
+                inline for (struct_info.fields) |field| {
+                    switch (@typeInfo(field.type)) {
+                        .bool, .int => continue,
+                        else => try encodeItem(@field(value, field.name), list),
+                    }
+                }
+            }
+        },
+        else => @compileError("Unsupported type " ++ @typeName(@TypeOf(value))),
+    }
+}
+
+// Helpers
+fn sizeOfValue(value: anytype) usize {
+    const info = @typeInfo(@TypeOf(value));
+
+    switch (info) {
+        .array => return value.len,
+        .pointer => switch (info.pointer.size) {
+            .Slice => return value.len,
+            else => return sizeOfValue(value.*),
+        },
+        .optional => return if (value == null)
+            @intCast(1)
+        else
+            1 + sizeOfValue(value.?),
+        .null => return @intCast(0),
+        .@"struct" => |struct_info| {
+            comptime var start: usize = 0;
+            inline for (struct_info.fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .int, .bool, .array => start += @sizeOf(field.type),
+                    .@"struct" => {
+                        start += sizeOfValue(field.type);
+                    },
+                    else => {},
+                }
+            }
+            return start;
+        },
+        else => @compileError("Unsupported type " ++ @typeName(@TypeOf(value))),
+    }
+    // It should never reach this
+    unreachable;
+}
+
+/// Checks if a given type is static
+pub inline fn isStaticType(comptime T: type) bool {
+    const info = @typeInfo(T);
+
+    switch (info) {
+        .bool, .int, .null => return true,
+        .array => return true,
+        .@"struct" => inline for (info.@"struct".fields) |field| {
+            if (!isStaticType(field.type)) {
+                return false;
+            }
+            return true;
+        },
+        .pointer => switch (info.pointer.size) {
+            .Many, .Slice, .C => return false,
+            .One => return isStaticType(info.Pointer.child),
+        },
+        else => @compileError("Unsupported type " ++ @typeName(T)),
+    }
+    // It should never reach this
+    unreachable;
+}
+
+/// Computes the size of a given int
+pub inline fn computeSize(int: u256) u8 {
+    inline for (1..32) |i| {
+        if (int < (1 << (8 * i))) {
+            return i;
+        }
+    }
+
+    return 32;
+}
+
+test "Bool" {
+    {
+        const encoded = try encodeSSZ(testing.allocator, true);
+        defer testing.allocator.free(encoded);
+
+        const slice = &[_]u8{0x01};
+
+        try testing.expectEqualSlices(u8, slice, encoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, false);
+        defer testing.allocator.free(encoded);
+
+        const slice = &[_]u8{0x00};
+
+        try testing.expectEqualSlices(u8, slice, encoded);
+    }
+}
+
+test "Int" {
+    {
+        const encoded = try encodeSSZ(testing.allocator, @as(u8, 69));
+        defer testing.allocator.free(encoded);
+
+        const slice = &[_]u8{0x45};
+
+        try testing.expectEqualSlices(u8, slice, encoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, @as(u16, 69));
+        defer testing.allocator.free(encoded);
+
+        const slice = &[_]u8{ 0x45, 0x00 };
+
+        try testing.expectEqualSlices(u8, slice, encoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, @as(u32, 69));
+        defer testing.allocator.free(encoded);
+
+        const slice = &[_]u8{ 0x45, 0x00, 0x00, 0x00 };
+
+        try testing.expectEqualSlices(u8, slice, encoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, @as(i32, -69));
+        defer testing.allocator.free(encoded);
+
+        const slice = &[_]u8{ 0xBB, 0xFF, 0xFF, 0xFF };
+
+        try testing.expectEqualSlices(u8, slice, encoded);
+    }
+}
+
+test "Arrays" {
+    {
+        const encoded = try encodeSSZ(testing.allocator, [_]bool{ true, false, true, true, false, false, false });
+        defer testing.allocator.free(encoded);
+
+        const slice = [_]u8{0b00001101};
+
+        try testing.expectEqualSlices(u8, &slice, encoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, [_]bool{ true, false, true, true, false, false, false, true });
+        defer testing.allocator.free(encoded);
+
+        const slice = [_]u8{0b10001101};
+
+        try testing.expectEqualSlices(u8, &slice, encoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, [_]bool{ true, false, true, true, false, false, false, true, false, true, false, true });
+        defer testing.allocator.free(encoded);
+
+        const slice = [_]u8{ 0x8D, 0x0A };
+
+        try testing.expectEqualSlices(u8, &slice, encoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, [_]u16{ 0xABCD, 0xEF01 });
+        defer testing.allocator.free(encoded);
+
+        const slice = &[_]u8{ 0xCD, 0xAB, 0x01, 0xEF };
+
+        try testing.expectEqualSlices(u8, slice, encoded);
+    }
+}
+
+test "Struct" {
+    {
+        const data = .{
+            .uint8 = @as(u8, 1),
+            .uint32 = @as(u32, 3),
+            .boolean = true,
+        };
+        const encoded = try encodeSSZ(testing.allocator, data);
+        defer testing.allocator.free(encoded);
+
+        const slice = [_]u8{ 1, 3, 0, 0, 0, 1 };
+        try testing.expectEqualSlices(u8, &slice, encoded);
+    }
+    {
+        const data = .{
+            .name = "James",
+            .age = @as(u8, 32),
+            .company = "DEV Inc.",
+        };
+        const encoded = try encodeSSZ(testing.allocator, data);
+        defer testing.allocator.free(encoded);
+
+        const slice = [_]u8{ 9, 0, 0, 0, 32, 14, 0, 0, 0, 74, 97, 109, 101, 115, 68, 69, 86, 32, 73, 110, 99, 46 };
+        try testing.expectEqualSlices(u8, &slice, encoded);
+    }
+}
+
+test "Decoded Bool" {
+    {
+        const decoded = try decodeSSZ(bool, &[_]u8{0x01});
+
+        try testing.expect(decoded);
+    }
+    {
+        const decoded = try decodeSSZ(bool, &[_]u8{0x00});
+
+        try testing.expect(!decoded);
+    }
+}
+
+test "Decoded Int" {
+    {
+        const decoded = try decodeSSZ(u8, &[_]u8{0x45});
+        try testing.expectEqual(69, decoded);
+    }
+    {
+        const decoded = try decodeSSZ(u16, &[_]u8{ 0x45, 0x00 });
+        try testing.expectEqual(69, decoded);
+    }
+    {
+        const decoded = try decodeSSZ(u32, &[_]u8{ 0x45, 0x00, 0x00, 0x00 });
+        try testing.expectEqual(69, decoded);
+    }
+    {
+        const decoded = try decodeSSZ(i32, &[_]u8{ 0xBB, 0xFF, 0xFF, 0xFF });
+        try testing.expectEqual(-69, decoded);
+    }
+}
+
+test "Decoded String" {
+    {
+        const slice: []const u8 = "FOO";
+
+        const decoded = try decodeSSZ([]const u8, slice);
+
+        try testing.expectEqualStrings(slice, decoded);
+    }
+    {
+        const slice = "FOO";
+
+        const decoded = try decodeSSZ([]const u8, slice);
+
+        try testing.expectEqualStrings(slice, decoded);
+    }
+    {
+        const Enum = enum { foo, bar };
+
+        const encode = try encodeSSZ(testing.allocator, Enum.foo);
+        defer testing.allocator.free(encode);
+
+        const decoded = try decodeSSZ(Enum, encode);
+
+        try testing.expectEqual(Enum.foo, decoded);
+    }
+}
+
+test "Decoded Array" {
+    {
+        const encoded = [_]bool{ true, false, true, true, false, false, false, true, false, true, false, true };
+
+        const slice = [_]u8{ 0x8D, 0x0A };
+
+        const decoded = try decodeSSZ([12]bool, &slice);
+
+        try testing.expectEqualSlices(bool, &encoded, &decoded);
+    }
+    {
+        const encoded = [_]u16{ 0xABCD, 0xEF01 };
+
+        const slice = &[_]u8{ 0xCD, 0xAB, 0x01, 0xEF };
+
+        const decoded = try decodeSSZ([2]u16, slice);
+
+        try testing.expectEqualSlices(u16, &encoded, &decoded);
+    }
+    {
+        const encoded = try encodeSSZ(testing.allocator, pastries);
+        defer testing.allocator.free(encoded);
+        const decoded = try decodeSSZ([2]Pastry, encoded);
+
+        try testing.expectEqualDeep(pastries, decoded);
+    }
+}
+
+const Pastry = struct {
+    name: []const u8,
+    weight: u16,
+};
+
+const pastries = [_]Pastry{
+    Pastry{
+        .name = "croissant",
+        .weight = 20,
+    },
+    Pastry{
+        .name = "Herrentorte",
+        .weight = 500,
+    },
+};
+
+test "Decode Struct" {
+    const pastry = Pastry{
+        .name = "croissant",
+        .weight = 20,
+    };
+
+    const encoded = try encodeSSZ(testing.allocator, pastry);
+    defer testing.allocator.free(encoded);
+
+    const decoded = try decodeSSZ(Pastry, encoded);
+
+    try testing.expectEqualDeep(pastry, decoded);
+}
+
+test "Decode Union" {
+    const Union = union(enum) {
+        foo: u32,
+        bar: bool,
+    };
+
+    {
+        const un = Union{ .foo = 69 };
+        const encoded = try encodeSSZ(testing.allocator, un);
+        defer testing.allocator.free(encoded);
+
+        const decoded = try decodeSSZ(Union, encoded);
+
+        try testing.expectEqualDeep(un, decoded);
+    }
+    {
+        const un = Union{ .bar = true };
+        const encoded = try encodeSSZ(testing.allocator, un);
+        defer testing.allocator.free(encoded);
+
+        const decoded = try decodeSSZ(Union, encoded);
+
+        try testing.expectEqualDeep(un, decoded);
+    }
+}
+
+test "Decode Optional" {
+    const foo: ?u32 = 69;
+
+    const encoded = try encodeSSZ(testing.allocator, foo);
+    defer testing.allocator.free(encoded);
+
+    const decoded = try decodeSSZ(?u32, encoded);
+
+    try testing.expectEqualDeep(foo, decoded);
+}
+
+test "Decode Vector" {
+    {
+        const encoded: @Vector(12, bool) = .{ true, false, true, true, false, false, false, true, false, true, false, true };
+        const slice = [_]u8{ 0x8D, 0x0A };
+
+        const decoded = try decodeSSZ(@Vector(12, bool), &slice);
+
+        try testing.expectEqualDeep(encoded, decoded);
+    }
+    {
+        const encoded: @Vector(2, u16) = .{ 0xABCD, 0xEF01 };
+        const slice = &[_]u8{ 0xCD, 0xAB, 0x01, 0xEF };
+
+        const decoded = try decodeSSZ(@Vector(2, u16), slice);
+
+        try testing.expectEqualDeep(encoded, decoded);
+    }
+}
 
 /// Number of bytes per chunk.
 const BYTES_PER_CHUNK = 32;
@@ -14,332 +726,11 @@ const BYTES_PER_CHUNK = 32;
 /// Number of bytes per serialized length offset.
 const BYTES_PER_LENGTH_OFFSET = 4;
 
-// Determine the serialized size of an object so that
-// the code serializing of variable-size objects can
-// determine the offset to the next object.
-fn serializedSize(comptime T: type, data: T) !usize {
-    const info = @typeInfo(T);
-    return switch (info) {
-        .Array => data.len,
-        .Pointer => switch (info.Pointer.size) {
-            .Slice => data.len,
-            else => serializedSize(info.Pointer.child, data.*),
-        },
-        .Optional => if (data == null)
-            @as(usize, 1)
-        else
-            1 + try serializedSize(info.Optional.child, data.?),
-        .Null => @as(usize, 0),
-        else => error.NoSerializedSizeAvailable,
-    };
-}
-
-/// Returns true if an object is of fixed size
-fn isFixedSizeObject(comptime T: type) !bool {
-    const info = @typeInfo(T);
-    switch (info) {
-        .Bool, .Int, .Null => return true,
-        .Array => return false,
-        .Struct => inline for (info.Struct.fields) |field| {
-            if (!try isFixedSizeObject(field.type)) {
-                return false;
-            }
-        },
-        .Pointer => switch (info.Pointer.size) {
-            .Many, .Slice, .C => return false,
-            .One => return isFixedSizeObject(info.Pointer.child),
-        },
-        else => return error.UnknownType,
-    }
-    return true;
-}
-
-/// Provides the generic serialization of any `data` var to SSZ. The
-/// serialization is written to the `ArrayList` `l`.
-pub fn serialize(comptime T: type, data: T, l: *ArrayList(u8)) !void {
-    const info = @typeInfo(T);
-    switch (info) {
-        .Array => {
-            // Bitvector[N] or vector?
-            if (info.Array.child == bool) {
-                var byte: u8 = 0;
-                for (data, 0..) |bit, index| {
-                    if (bit) {
-                        byte |= @as(u8, 1) << @as(u3, @truncate(index));
-                    }
-
-                    if (index % 8 == 7) {
-                        try l.append(byte);
-                        byte = 0;
-                    }
-                }
-
-                // Write the last byte if the length
-                // is not byte-aligned
-                if (data.len % 8 != 0) {
-                    try l.append(byte);
-                }
-            } else {
-                // If the item type is fixed-size, serialize inline,
-                // otherwise, create an array of offsets and then
-                // serialize each object afterwards.
-                if (try isFixedSizeObject(info.Array.child)) {
-                    for (data) |item| {
-                        try serialize(info.Array.child, item, l);
-                    }
-                } else {
-                    // Size of the buffer before anything is
-                    // written to it.
-                    var start = l.items.len;
-
-                    // Reserve the space for the offset
-                    for (data) |_| {
-                        _ = try l.writer().writeInt(u32, 0, std.builtin.Endian.little);
-                    }
-
-                    // Now serialize one item after the other
-                    // and update the offset list with its location.
-                    for (data) |item| {
-                        std.mem.writeInt(u32, l.items[start .. start + 4][0..4], @as(u32, @truncate(l.items.len)), std.builtin.Endian.little);
-                        _ = try serialize(info.Array.child, item, l);
-                        start += 4;
-                    }
-                }
-            }
-        },
-        .Bool => {
-            if (data) {
-                try l.append(1);
-            } else {
-                try l.append(0);
-            }
-        },
-        .Int => |int| {
-            switch (int.bits) {
-                8, 16, 32, 64, 128, 256 => {},
-                else => return error.InvalidSerializedIntLengthType,
-            }
-            _ = try l.writer().writeInt(T, data, std.builtin.Endian.little);
-        },
-        .Pointer => {
-            // Bitlist[N] or list?
-            switch (info.Pointer.size) {
-                .Slice, .One => {
-                    if (@sizeOf(info.Pointer.child) == 1) {
-                        _ = try l.writer().write(data);
-                    } else {
-                        for (data) |item| {
-                            try serialize(@TypeOf(item), item, l);
-                        }
-                    }
-                },
-                else => return error.UnSupportedPointerType,
-            }
-        },
-        .Struct => {
-            // First pass, accumulate the fixed sizes
-            comptime var var_start = 0;
-            inline for (info.Struct.fields) |field| {
-                if (@typeInfo(field.type) == .Int or @typeInfo(field.type) == .Bool) {
-                    var_start += @sizeOf(field.type);
-                } else {
-                    var_start += 4;
-                }
-            }
-
-            // Second pass: intertwine fixed fields and variables offsets
-            var var_acc = @as(usize, var_start); // variable part size accumulator
-            inline for (info.Struct.fields) |field| {
-                switch (@typeInfo(field.type)) {
-                    .Int, .Bool => {
-                        try serialize(field.type, @field(data, field.name), l);
-                    },
-                    else => {
-                        try serialize(u32, @as(u32, @truncate(var_acc)), l);
-                        var_acc += try serializedSize(field.type, @field(data, field.name));
-                    },
-                }
-            }
-
-            // Third pass: add variable fields at the end
-            if (var_acc > var_start) {
-                inline for (info.Struct.fields) |field| {
-                    switch (@typeInfo(field.type)) {
-                        .Int, .Bool => {
-                            // skip fixed-size fields
-                        },
-                        else => {
-                            try serialize(field.type, @field(data, field.name), l);
-                        },
-                    }
-                }
-            }
-        },
-        // Nothing to be added to the payload
-        .Null => {},
-        // Optionals are like unions, but their 0 value has to be 0.
-        .Optional => {
-            if (data != null) {
-                _ = try l.writer().writeInt(u8, 1, std.builtin.Endian.little);
-                try serialize(info.Optional.child, data.?, l);
-            } else {
-                _ = try l.writer().writeInt(u8, 0, std.builtin.Endian.little);
-            }
-        },
-        .Union => {
-            if (info.Union.tag_type == null) {
-                return error.UnionIsNotTagged;
-            }
-            inline for (info.Union.fields, 0..) |f, index| {
-                if (@intFromEnum(data) == index) {
-                    _ = try l.writer().writeInt(u8, index, std.builtin.Endian.little);
-                    try serialize(f.type, @field(data, f.name), l);
-                    return;
-                }
-            }
-        },
-        else => {
-            return error.UnknownType;
-        },
-    }
-}
-
-/// Takes a byte array containing the serialized payload of type `T` (with
-/// possible trailing data) and deserializes it into the `T` object pointed
-/// at by `out`.
-pub fn deserialize(comptime T: type, serialized: []const u8, out: *T) !void {
-    const info = @typeInfo(T);
-    switch (info) {
-        .Array => {
-            // Bitvector[N] or regular vector?
-            if (info.Array.child == bool) {
-                for (serialized, 0..) |byte, bindex| {
-                    var i = @as(u8, 0);
-                    var b = byte;
-                    while (bindex * 8 + i < out.len and i < 8) : (i += 1) {
-                        out[bindex * 8 + i] = b & 1 == 1;
-                        b >>= 1;
-                    }
-                }
-            } else {
-                const U = info.Array.child;
-                if (try isFixedSizeObject(U)) {
-                    comptime var i = 0;
-                    const pitch = @sizeOf(U);
-                    inline while (i < out.len) : (i += pitch) {
-                        try deserialize(U, serialized[i * pitch .. (i + 1) * pitch], &out[i]);
-                    }
-                } else {
-                    // first variable index is also the size of the list
-                    // of indices. Recast that list as a []const u32.
-                    const size = std.mem.readInt(u32, serialized[0..4], std.builtin.Endian.little) / @sizeOf(u32);
-                    const indices = std.mem.bytesAsSlice(u32, serialized[0 .. size * 4]);
-                    var i = @as(usize, 0);
-                    while (i < size) : (i += 1) {
-                        const end = if (i < size - 1) indices[i + 1] else serialized.len;
-                        const start = indices[i];
-                        if (start >= serialized.len or end > serialized.len) {
-                            return error.IndexOutOfBounds;
-                        }
-                        try deserialize(U, serialized[start..end], &out[i]);
-                    }
-                }
-            }
-        },
-        .Bool => out.* = (serialized[0] == 1),
-        .Int => {
-            const N = @sizeOf(T);
-            out.* = std.mem.readInt(T, serialized[0..N], std.builtin.Endian.little);
-        },
-        .Optional => {
-            const index: u8 = serialized[0];
-            if (index != 0) {
-                var x: info.Optional.child = undefined;
-                try deserialize(info.Optional.child, serialized[1..], &x);
-                out.* = x;
-            } else {
-                out.* = null;
-            }
-        },
-        // Data is not copied in this function, copy is therefore
-        // the responsibility of the caller.
-        .Pointer => out.* = serialized[0..],
-        .Struct => {
-            // Calculate the number of variable fields in the
-            // struct.
-            comptime var n_var_fields = 0;
-            comptime {
-                for (info.Struct.fields) |field| {
-                    switch (@typeInfo(field.type)) {
-                        .Int, .Bool => {},
-                        else => n_var_fields += 1,
-                    }
-                }
-            }
-
-            var indices: [n_var_fields]u32 = undefined;
-
-            // First pass, read the value of each fixed-size field,
-            // and write down the start offset of each variable-sized
-            // field.
-            comptime var i = 0;
-            comptime var variable_field_index = 0;
-            inline for (info.Struct.fields) |field| {
-                switch (@typeInfo(field.type)) {
-                    .Bool, .Int => {
-                        // Direct deserialize
-                        try deserialize(field.type, serialized[i .. i + @sizeOf(field.type)], &@field(out.*, field.name));
-                        i += @sizeOf(field.type);
-                    },
-                    else => {
-                        try deserialize(u32, serialized[i .. i + 4], &indices[variable_field_index]);
-                        i += 4;
-                        variable_field_index += 1;
-                    },
-                }
-            }
-
-            // Second pass, deserialize each variable-sized value
-            // now that their offset is known.
-            comptime var last_index = 0;
-            inline for (info.Struct.fields) |field| {
-                switch (@typeInfo(field.type)) {
-                    .Bool, .Int => {}, // covered by the previous pass
-                    else => {
-                        const end = if (last_index == indices.len - 1) serialized.len else indices[last_index + 1];
-                        try deserialize(field.type, serialized[indices[last_index]..end], &@field(out.*, field.name));
-                        last_index += 1;
-                    },
-                }
-            }
-        },
-        .Union => {
-            // Read the type index
-            var union_index: u8 = undefined;
-            try deserialize(u8, serialized, &union_index);
-
-            // Use the index to figure out which type must
-            // be deserialized.
-            inline for (info.Union.fields, 0..) |field, index| {
-                if (index == union_index) {
-                    // &@field(out.*, field.name) can not be used directly,
-                    // because this field type hasn't been activated at this
-                    // stage.
-                    var data: field.type = undefined;
-                    try deserialize(field.type, serialized[1..], &data);
-                    out.* = @unionInit(T, field.name, data);
-                }
-            }
-        },
-        else => return error.NotImplemented,
-    }
-}
-
 fn mixInLength(root: [32]u8, length: [32]u8, out: *[32]u8) void {
     var hasher = sha256.init(sha256.Options{});
     hasher.update(root[0..]);
     hasher.update(length[0..]);
-    hasher.final(out[0..]);
+    hasher.final(out);
 }
 
 test "mixInLength" {
@@ -359,9 +750,9 @@ fn mixInSelector(root: [32]u8, comptime selector: usize, out: *[32]u8) void {
     var hasher = sha256.init(sha256.Options{});
     hasher.update(root[0..]);
     var tmp = [_]u8{0} ** 32;
-    std.mem.writeInt(@TypeOf(selector), tmp[0..@sizeOf(@TypeOf(selector))], selector, std.builtin.Endian.little);
+    std.mem.writeInt(@TypeOf(selector), tmp[0..@sizeOf(@TypeOf(selector))], selector, .little);
     hasher.update(tmp[0..]);
-    hasher.final(out[0..]);
+    hasher.final(out);
 }
 
 test "mixInSelector" {
@@ -375,23 +766,20 @@ test "mixInSelector" {
     try std.testing.expect(std.mem.eql(u8, mixin[0..], expected[0..]));
 }
 
-/// Calculates the number of leaves needed for the merkelization
-/// of this type.
 pub fn chunkCount(comptime T: type) usize {
     const info = @typeInfo(T);
     switch (info) {
-        .Int, .Bool => return 1,
-        .Pointer => return chunkCount(info.Pointer.child),
-        // the chunk size of an array depends on its type
-        .Array => switch (@typeInfo(info.Array.child)) {
+        .int, .bool => return 1,
+        .pointer => return chunkCount(info.pointer.child),
+        .array => switch (@typeInfo(info.array.child)) {
             // Bitvector[N]
-            .Bool => return (info.Array.len + 255) / 256,
+            .bool => return (info.array.len + 255) / 256,
             // Vector[B,N]
-            .Int => return (info.Array.len * @sizeOf(info.Array.child) + 31) / 32,
+            .int => return (info.array.len * @sizeOf(info.array.child) + 31) / 32,
             // Vector[C,N]
-            else => return info.Array.len,
+            else => return info.array.len,
         },
-        .Struct => return info.Struct.fields.len,
+        .@"struct" => return info.@"struct".fields.len,
         else => return error.NotSupported,
     }
 }
@@ -399,10 +787,14 @@ pub fn chunkCount(comptime T: type) usize {
 const chunk = [BYTES_PER_CHUNK]u8;
 const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
 
-fn pack(comptime T: type, values: T, l: *ArrayList(u8)) ![]chunk {
-    try serialize(T, values, l);
+fn pack(value: anytype, l: *ArrayList(u8)) ![]chunk {
+    const encoded = try encodeSSZ(l.allocator, value);
+    try l.appendSlice(encoded);
+    l.allocator.free(encoded);
+
     const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
-    _ = try l.writer().write(zero_chunk[0..padding_size]);
+    try l.appendSlice(zero_chunk[0..padding_size]);
+
     return std.mem.bytesAsSlice(chunk, l.items);
 }
 
@@ -410,7 +802,8 @@ test "pack u32" {
     var expected: [32]u8 = undefined;
     var list = ArrayList(u8).init(std.testing.allocator);
     defer list.deinit();
-    const out = try pack(u32, 0xdeadbeef, &list);
+    const data: u32 = 0xdeadbeef;
+    const out = try pack(data, &list);
 
     _ = try std.fmt.hexToBytes(expected[0..], "efbeadde00000000000000000000000000000000000000000000000000000000");
 
@@ -421,7 +814,7 @@ test "pack bool" {
     var expected: [32]u8 = undefined;
     var list = ArrayList(u8).init(std.testing.allocator);
     defer list.deinit();
-    const out = try pack(bool, true, &list);
+    const out = try pack(true, &list);
 
     _ = try std.fmt.hexToBytes(expected[0..], "0100000000000000000000000000000000000000000000000000000000000000");
 
@@ -432,7 +825,8 @@ test "pack string" {
     var expected: [128]u8 = undefined;
     var list = ArrayList(u8).init(std.testing.allocator);
     defer list.deinit();
-    const out = try pack([]const u8, "a" ** 100, &list);
+    const data: []const u8 = "a" ** 100;
+    const out = try pack(data, &list);
 
     _ = try std.fmt.hexToBytes(expected[0..], "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000000000000000000000000000000000000000000000000000000");
 
@@ -473,36 +867,34 @@ test "next power of 2" {
     try std.testing.expectError(error.OverflowsUSize, nextPowOfTwo(std.math.maxInt(usize)));
 }
 
-// merkleize recursively calculates the root hash of a Merkle tree.
+const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
+
 pub fn merkleize(chunks: []chunk, limit: ?usize, out: *[32]u8) anyerror!void {
-    // Calculate the number of chunks to be padded, check the limit
     if (limit != null and chunks.len > limit.?) {
         return error.ChunkSizeExceedsLimit;
     }
+
     const size = try nextPowOfTwo(limit orelse chunks.len);
 
-    // Perform the merkelization
+    // Perform the merkleization.
     switch (size) {
-        0 => std.mem.copyForwards(u8, out.*[0..], zero_chunk[0..]),
-        1 => std.mem.copyForwards(u8, out.*[0..], chunks[0][0..]),
+        0 => std.mem.copyForwards(u8, out, &zero_chunk),
+        1 => std.mem.copyForwards(u8, out, chunks[0][0..]),
         else => {
-            // Merkleize the left side. If the number of chunks
-            // isn't enough to fill the entire width, complete
-            // with zeroes.
-            var digest = sha256.init(sha256.Options{});
+            var hasher = sha256.init(sha256.Options{});
             var buf: [32]u8 = undefined;
             const split = if (size / 2 < chunks.len) size / 2 else chunks.len;
             try merkleize(chunks[0..split], size / 2, &buf);
-            digest.update(buf[0..]);
+            hasher.update(buf[0..]);
 
-            // Merkleize the right side. If the number of chunks only
-            // covers the first half, directly input the hashed zero-
-            // filled subtrie.
             if (size / 2 < chunks.len) {
                 try merkleize(chunks[size / 2 ..], size / 2, &buf);
-                digest.update(buf[0..]);
-            } else digest.update(hashes_of_zero[size / 2 - 1][0..]);
-            digest.final(out);
+                hasher.update(buf[0..]);
+            } else {
+                const power = std.math.log2(size);
+                hasher.update(hashes_of_zero[power - 1][0..]);
+            }
+            hasher.final(out);
         },
     }
 }
@@ -510,7 +902,8 @@ pub fn merkleize(chunks: []chunk, limit: ?usize, out: *[32]u8) anyerror!void {
 test "merkleize a string" {
     var list = ArrayList(u8).init(std.testing.allocator);
     defer list.deinit();
-    const chunks = try pack([]const u8, "a" ** 100, &list);
+    const data: []const u8 = "a" ** 100;
+    const chunks = try pack(data, &list);
     var out: [32]u8 = undefined;
     try merkleize(chunks, null, &out);
     // Build the expected tree
@@ -539,7 +932,7 @@ test "merkleize a boolean" {
     var list = ArrayList(u8).init(std.testing.allocator);
     defer list.deinit();
 
-    var chunks = try pack(bool, false, &list);
+    var chunks = try pack(false, &list);
     var expected = [_]u8{0} ** BYTES_PER_CHUNK;
     var out: [BYTES_PER_CHUNK]u8 = undefined;
     try merkleize(chunks, null, &out);
@@ -549,7 +942,7 @@ test "merkleize a boolean" {
     var list2 = ArrayList(u8).init(std.testing.allocator);
     defer list2.deinit();
 
-    chunks = try pack(bool, true, &list2);
+    chunks = try pack(true, &list2);
     expected[0] = 1;
     try merkleize(chunks, null, &out);
     try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
@@ -558,7 +951,7 @@ test "merkleize a boolean" {
 test "merkleize a bytes16 vector with one element" {
     var list = ArrayList(u8).init(std.testing.allocator);
     defer list.deinit();
-    const chunks = try pack([16]u8, [_]u8{0xaa} ** 16, &list);
+    const chunks = try pack([_]u8{0xaa} ** 16, &list);
     var expected: [32]u8 = [_]u8{0xaa} ** 16 ++ [_]u8{0x00} ** 16;
     var out: [32]u8 = undefined;
     try merkleize(chunks, null, &out);
@@ -567,16 +960,15 @@ test "merkleize a bytes16 vector with one element" {
 
 fn packBits(bits: []const bool, l: *ArrayList(u8)) ![]chunk {
     var byte: u8 = 0;
-    for (bits, 0..) |bit, bitidx| {
+    for (bits, 0..) |bit, bitIdx| {
         if (bit) {
-            byte |= @as(u8, 1) << @as(u3, @truncate(7 - bitidx % 8));
+            byte |= @as(u8, 1) << @as(u3, @truncate(7 - bitIdx % 8));
         }
-        if (bitidx % 8 == 7 or bitidx == bits.len - 1) {
+        if (bitIdx % 8 == 7 or bitIdx == bits.len - 1) {
             try l.append(byte);
             byte = 0;
         }
     }
-
     // pad the last chunk with 0s
     const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
     _ = try l.writer().write(zero_chunk[0..padding_size]);
@@ -584,39 +976,35 @@ fn packBits(bits: []const bool, l: *ArrayList(u8)) ![]chunk {
     return std.mem.bytesAsSlice(chunk, l.items);
 }
 
-pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator) !void {
-    const type_info = @typeInfo(T);
+pub fn hashTreeRoot(value: anytype, out: *[32]u8, allocator: Allocator) !void {
+    const type_info = @typeInfo(@TypeOf(value));
     switch (type_info) {
-        .Int, .Bool => {
-            var list = ArrayList(u8).init(allctr);
+        .int, .bool => {
+            var list = ArrayList(u8).init(allocator);
             defer list.deinit();
-            const chunks = try pack(T, value, &list);
+            const chunks = try pack(value, &list);
             try merkleize(chunks, null, out);
         },
-        .Array => {
-            // Check if the child is a basic type. If so, return
-            // the merkle root of its chunked serialization.
-            // Otherwise, it is a composite object and the chunks
-            // are the merkle roots of its elements.
-            switch (@typeInfo(type_info.Array.child)) {
-                .Int => {
-                    var list = ArrayList(u8).init(allctr);
+        .array => {
+            switch (@typeInfo(type_info.array.child)) {
+                .int => {
+                    var list = ArrayList(u8).init(allocator);
                     defer list.deinit();
-                    const chunks = try pack(T, value, &list);
+                    const chunks = try pack(value, &list);
                     try merkleize(chunks, null, out);
                 },
-                .Bool => {
-                    var list = ArrayList(u8).init(allctr);
+                .bool => {
+                    var list = ArrayList(u8).init(allocator);
                     defer list.deinit();
-                    const chunks = try packBits(value[0..], &list);
-                    try merkleize(chunks, chunkCount(T), out);
+                    const chunks = try packBits(&value, &list);
+                    try merkleize(chunks, null, out);
                 },
-                .Array => {
-                    var chunks = ArrayList(chunk).init(allctr);
+                .array => {
+                    var chunks = ArrayList(chunk).init(allocator);
                     defer chunks.deinit();
                     var tmp: chunk = undefined;
                     for (value) |item| {
-                        try hashTreeRoot(@TypeOf(item), item, &tmp, allctr);
+                        try hashTreeRoot(item, &tmp, allocator);
                         try chunks.append(tmp);
                     }
                     try merkleize(chunks.items, null, out);
@@ -624,16 +1012,48 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                 else => return error.NotSupported,
             }
         },
-        .Pointer => {
-            switch (type_info.Pointer.size) {
-                .One => hashTreeRoot(type_info.Pointer.child, value.*, out, allctr),
+        .pointer => {
+            switch (type_info.pointer.size) {
+                .One => try hashTreeRoot(value.*, out, allocator),
                 .Slice => {
-                    switch (@typeInfo(type_info.Pointer.child)) {
-                        .Int => {
-                            var list = ArrayList(u8).init(allctr);
+                    const slice_info = @typeInfo(type_info.pointer.child);
+                    switch (slice_info) {
+                        .int => {
+                            var list = ArrayList(u8).init(allocator);
                             defer list.deinit();
-                            const chunks = try pack(T, value, &list);
-                            merkleize(chunks, null, out);
+                            const chunks = try pack(value, &list);
+                            // TODO: slice should have a limit
+                            try merkleize(chunks, null, out);
+                            var length: [32]u8 = [_]u8{0} ** 32;
+                            std.mem.writeInt(u64, length[0..8], value.len, .little);
+                            mixInLength(out.*, length, out);
+                        },
+                        .array => {
+                            switch (@typeInfo(slice_info.array.child)) {
+                                .int => {
+                                    var list = ArrayList(u8).init(allocator);
+                                    defer list.deinit();
+                                    const chunks = try pack(value, &list);
+                                    try merkleize(chunks, null, out);
+                                },
+                                .bool => {
+                                    var list = ArrayList(u8).init(allocator);
+                                    defer list.deinit();
+                                    const chunks = try packBits(value, list);
+                                    try merkleize(chunks, null, out);
+                                },
+                                .array => {
+                                    var chunks = ArrayList(chunk).init(allocator);
+                                    defer chunks.deinit();
+                                    var tmp: chunk = undefined;
+                                    for (value) |item| {
+                                        try hashTreeRoot(item, &tmp, allocator);
+                                        try chunks.append(tmp);
+                                    }
+                                    try merkleize(chunks.items, null, out);
+                                },
+                                else => return error.NotSupported,
+                            }
                         },
                         else => return error.UnSupportedPointerType,
                     }
@@ -641,48 +1061,35 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                 else => return error.UnSupportedPointerType,
             }
         },
-        .Struct => {
-            var chunks = ArrayList(chunk).init(allctr);
+        .@"struct" => {
+            var chunks = ArrayList(chunk).init(allocator);
             defer chunks.deinit();
             var tmp: chunk = undefined;
-            inline for (type_info.Struct.fields) |f| {
-                try hashTreeRoot(f.type, @field(value, f.name), &tmp, allctr);
+            inline for (type_info.@"struct".fields) |f| {
+                try hashTreeRoot(@field(value, f.name), &tmp, allocator);
                 try chunks.append(tmp);
             }
             try merkleize(chunks.items, null, out);
         },
-        // An optional is a union with `None` as first value.
-        .Optional => if (value != null) {
+        .optional => if (value != null) {
             var tmp: chunk = undefined;
-            try hashTreeRoot(type_info.Optional.child, value.?, &tmp, allctr);
+            try hashTreeRoot(value.?, &tmp, allocator);
             mixInSelector(tmp, 1, out);
         } else {
             mixInSelector(zero_chunk, 0, out);
         },
-        .Union => {
-            if (type_info.Union.tag_type == null) {
+        .@"union" => {
+            if (type_info.@"union".tag_type == null) {
                 return error.UnionIsNotTagged;
             }
-            inline for (type_info.Union.fields, 0..) |f, index| {
+            inline for (type_info.@"union".fields, 0..) |f, index| {
                 if (@intFromEnum(value) == index) {
                     var tmp: chunk = undefined;
-                    try hashTreeRoot(f.type, @field(value, f.name), &tmp, allctr);
+                    try hashTreeRoot(@field(value, f.name), &tmp, allocator);
                     mixInSelector(tmp, index, out);
                 }
             }
         },
         else => return error.NotSupported,
     }
-}
-
-// used at comptime to generate a bitvector from a byte vector
-fn bytesToBits(comptime N: usize, src: [N]u8) [N * 8]bool {
-    var bitvector: [N * 8]bool = undefined;
-    for (src, 0..) |byte, idx| {
-        var i = 0;
-        while (i < 8) : (i += 1) {
-            bitvector[i + idx * 8] = ((byte >> (7 - i)) & 1) == 1;
-        }
-    }
-    return bitvector;
 }


### PR DESCRIPTION
More specifically,`v0.14.0-dev.2051+b1361f237`.

This is taken from [zephyrus' ssz implementation](https://github.com/zen-eth/zephyrus/blob/main/src/ssz/ssz.zig) with some changes.

I also imported the [unit tests](https://github.com/gballet/ssz.zig/blob/master/src/tests.zig) from gballet's repo, but it's a bit messy - I will clean it up in followup PRs.

For now, the tests pass!